### PR TITLE
Add Dockerfile

### DIFF
--- a/raspberry-pi/python/Dockerfile
+++ b/raspberry-pi/python/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7
+
+ENV app /app
+RUN mkdir $app
+WORKDIR $app
+ADD . $app
+
+RUN apt-get update && \
+    apt-get install -y sqlite3 libusb-1.0-0-dev
+RUN sqlite3 attendance.db < migrate.sql
+RUN pip install -r requirements.txt
+
+CMD python attendance.py


### PR DESCRIPTION
docker run できるけど USB 周りでエラーでるなー。コンテナからホストマシンの USB デバイスを見るのってどうすればいいんだろう?

```
Please tap your card on the nfc reader. Waiting...
Traceback (most recent call last):
  File "attendance.py", line 150, in <module>
    clf = nfc.ContactlessFrontend('usb')
  File "/usr/local/lib/python2.7/site-packages/nfc/clf/__init__.py", line 71, in __init__
    if path and not self.open(path):
  File "/usr/local/lib/python2.7/site-packages/nfc/clf/__init__.py", line 145, in open
    self.device = device.connect(path)
  File "/usr/local/lib/python2.7/site-packages/nfc/clf/device.py", line 66, in connect
    found = transport.USB.find(path)
  File "/usr/local/lib/python2.7/site-packages/nfc/clf/transport.py", line 194, in find
    devices = context.getDeviceList(skip_on_error=True)
  File "/usr/local/lib/python2.7/site-packages/usb1.py", line 2124, in getDeviceList
    skip_on_error=skip_on_access_error or skip_on_error,
  File "/usr/local/lib/python2.7/site-packages/usb1.py", line 1983, in wrapper
    with refcount(self):
  File "/usr/local/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/usr/local/lib/python2.7/site-packages/usb1.py", line 1972, in refcount
    self.open()
  File "/usr/local/lib/python2.7/site-packages/usb1.py", line 2038, in open
    mayRaiseUSBError(libusb1.libusb_init(byref(self.__context_p)))
  File "/usr/local/lib/python2.7/site-packages/usb1.py", line 121, in mayRaiseUSBError
    raiseUSBError(value)
  File "/usr/local/lib/python2.7/site-packages/usb1.py", line 117, in raiseUSBError
    raise STATUS_TO_EXCEPTION_DICT.get(value, USBError)(value)
usb1.USBErrorOther: LIBUSB_ERROR_OTHER [-99]
```
